### PR TITLE
Fix leaking h2 and h3 styles

### DIFF
--- a/src/slices/CardsCarousel/index.vue
+++ b/src/slices/CardsCarousel/index.vue
@@ -61,7 +61,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 .c-carousel {
 	position: relative;
 }


### PR DESCRIPTION
Add 'scoped' property to the style tag for the CardsCarousel slice to prevent leak of h2 and h3 styles